### PR TITLE
Inject paper metadata alpha endpoints into Dropbox SDK

### DIFF
--- a/dropbox/paper/types.go
+++ b/dropbox/paper/types.go
@@ -688,6 +688,34 @@ func NewPaperDocExportResult(Owner string, Title string, Revision int64, MimeTyp
 	return s
 }
 
+// PaperDocGetMetadataResult : has no documentation (yet)
+type PaperDocGetMetadataResult struct {
+	RefPaperDoc
+	// Owner : The Paper doc owner's email address.
+	Owner string `json:"owner"`
+	// Title : The Paper doc title.
+	Title string `json:"title"`
+	// CreatedDate : The paper doc creation data.
+	CreatedDate time.Time `json:"created_date,omitempty"`
+	// Revision : The Paper doc revision. Simply an ever increasing number.
+	Revision int64 `json:"revision"`
+	// LastUpdatedDate : The date when the paper doc was last edited
+	LastUpdatedDate time.Time `json:"last_updated_date,omitempty"`
+	// LastEditor : Email address of the last editor of the paper doc
+	LastEditor string `json:"last_editor"`
+}
+
+// NewPaperDocGetMetadataResult returns a new PaperDocGetMetadataResult instance
+func NewPaperDocGetMetadataResult(DocId string, Owner string, Title string, Revision int64, LastEditor string) *PaperDocGetMetadataResult {
+	s := new(PaperDocGetMetadataResult)
+	s.DocId = DocId
+	s.Owner = Owner
+	s.Title = Title
+	s.Revision = Revision
+	s.LastEditor = LastEditor
+	return s
+}
+
 // PaperDocPermissionLevel : has no documentation (yet)
 type PaperDocPermissionLevel struct {
 	dropbox.Tagged

--- a/dropbox/sdk.go
+++ b/dropbox/sdk.go
@@ -37,7 +37,7 @@ const (
 	hostAPI       = "api"
 	hostContent   = "content"
 	hostNotify    = "notify"
-	sdkVersion    = "5.6.0"
+	sdkVersion    = "5.7.0"
 	specVersion   = "0e697d7"
 )
 

--- a/generator/generate-sdk.sh
+++ b/generator/generate-sdk.sh
@@ -11,8 +11,8 @@ base_dir=$(dirname "$loc")
 spec_dir="$base_dir/dropbox-api-spec"
 gen_dir=$(dirname ${base_dir})/dropbox
 
-stone -v -a :all go_types.stoneg.py "$gen_dir" "$spec_dir"/*.stone
-stone -v -a :all go_client.stoneg.py "$gen_dir" "$spec_dir"/*.stone
+stone -v -a :all go_types.stoneg.py "$gen_dir" "$spec_dir"/*.stone "$base_dir"/injected-specs/*.stone
+stone -v -a :all go_client.stoneg.py "$gen_dir" "$spec_dir"/*.stone "$base_dir"/injected-specs/*.stone
 
 # Update SDK and API spec versions
 sdk_version=${1:-"5.0.0"}

--- a/generator/injected-specs/alpha_paper.stone
+++ b/generator/injected-specs/alpha_paper.stone
@@ -1,0 +1,44 @@
+namespace paper
+
+# Spec handwritten to gain access to alpha paper endpoints.
+# Taken from https://www.dropbox.com/developers/paper-api-alpha#paper-docs-get_metadata
+
+import common
+
+struct PaperDocGetMetadataResult extends RefPaperDoc
+
+    owner String
+        "The Paper doc owner's email address."
+
+    title String
+        "The Paper doc title."
+
+    created_date common.DropboxTimestamp?
+        "The paper doc creation data."
+
+    revision Int64
+        "The Paper doc revision. Simply an ever increasing number."
+
+    last_updated_date common.DropboxTimestamp?
+        "The date when the paper doc was last edited"
+
+    last_editor String
+        "Email address of the last editor of the paper doc"
+
+    # TODO: Add status to get archive vs. deletd?
+
+    example default
+        doc_id = "zO1E7coc54sE8IuMdUoxz"
+        owner = "james@example.com"
+        title = "Week one retention"
+        created_date = "2016-01-20T00:00:00Z"
+        revision = 456736745
+        last_updated_date = "2016-01-20T00:00:00Z"
+        last_editor = "james@example.com"
+
+
+route docs/get_metadata (RefPaperDoc, PaperDocGetMetadataResult, DocLookupError)
+    "Returns Paper doc metadata."
+    attrs
+        owner="neeva-h4x0rs"
+

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module dropbox-sdk-go-unofficial/m/v2
+
+go 1.13


### PR DESCRIPTION
This will NOT go upstream!

To ensure we can get modification time (and stop re-downloading data all the time), we use alpha paper endpoints to get the data.

It is highly unlikely these endpoints will be deprecated before the rest of the paper API (per discussions with actual Dropboxers).

As always a lot of this is generated code. You can just look at the .stone file.

Also added a go.mod file as go.mod replace (to local file system) requires the target have a go.mod